### PR TITLE
Fixing assertion feedback messages

### DIFF
--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -16,7 +16,7 @@ const compareWithBaseline = require('../lib/compare-with-baseline')
  * that order. Further assertions will compare against the screenshot that was
  * saved in the first execution of the assertion.
  *
- * @param {String} elementId Identifies the element that will be captured in the screenshot.
+ * @param elementId Identifies the element that will be captured in the screenshot. Could be string or page object.
  * @param {String} fileName Optional file name for this screenshot; defaults to the elementId
  * @param {NightwatchVRTOptions} settings Optional settings to override the defaults and `visual_regression_settings`
  * @param {String} message Optional message for `nightwatch` to log upon completion
@@ -27,7 +27,11 @@ exports.assertion = function screenshotIdenticalToBaseline(
     settings,
     message
 ) {
-
+    if (elementId.selector) {
+        elementId = elementId.selector
+    } else {
+        elementId = elementId;
+    }
     this.message = message || `Visual regression test results for element <${elementId}>.`
     this.expected = true
 
@@ -53,6 +57,11 @@ exports.assertion = function screenshotIdenticalToBaseline(
                 compareWithBaseline(this.api, screenshot, fileName, settings).then((result) => {
                     comparisonResult = result ? result : result.value
                     if(result.value === true && result.diff !== result.threshold) {
+                        if (elementId.selector) {
+                            elementId = elementId.selector
+                        } else {
+                            elementId = elementId;
+                        }
                         this.message = `The difference between the screenshots for <${elementId}> was ${result.diff} when ${result.threshold} was expected`
                     }
                     done()

--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -16,19 +16,19 @@ const compareWithBaseline = require('../lib/compare-with-baseline')
  * that order. Further assertions will compare against the screenshot that was
  * saved in the first execution of the assertion.
  *
- * @param {String} selector Identifies the element that will be captured in the screenshot.
- * @param {String} fileName Optional file name for this screenshot; defaults to the selector
+ * @param {String} elementId Identifies the element that will be captured in the screenshot.
+ * @param {String} fileName Optional file name for this screenshot; defaults to the elementId
  * @param {NightwatchVRTOptions} settings Optional settings to override the defaults and `visual_regression_settings`
  * @param {String} message Optional message for `nightwatch` to log upon completion
  */
 exports.assertion = function screenshotIdenticalToBaseline(
-    elementId = 'body',
+    elementId = elementId || 'body',
     fileName = elementId,
     settings,
     message
 ) {
 
-    this.message = message || `Visual regression test results for element <${elementId.selector}>.`
+    this.message = message || `Visual regression test results for element <${elementId}>.`
     this.expected = true
 
     this.pass = function pass(value) {
@@ -53,7 +53,7 @@ exports.assertion = function screenshotIdenticalToBaseline(
                 compareWithBaseline(this.api, screenshot, fileName, settings).then((result) => {
                     comparisonResult = result ? result : result.value
                     if(result.value === true && result.diff !== result.threshold) {
-                        this.message = `The difference between the screenshots for <${elementId.selector}> was ${result.diff} when ${result.threshold} was expected`
+                        this.message = `The difference between the screenshots for <${elementId}> was ${result.diff} when ${result.threshold} was expected`
                     }
                     done()
                 }, (reject) => {

--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -27,7 +27,9 @@ exports.assertion = function screenshotIdenticalToBaseline(
     settings,
     message
 ) {
-    if (elementId.selector) {
+    if (elementId === 'body') {
+        elementId = 'body';
+    } else if (elementId.selector) {
         elementId = elementId.selector
     } else {
         elementId = elementId;
@@ -57,7 +59,9 @@ exports.assertion = function screenshotIdenticalToBaseline(
                 compareWithBaseline(this.api, screenshot, fileName, settings).then((result) => {
                     comparisonResult = result ? result : result.value
                     if(result.value === true && result.diff !== result.threshold) {
-                        if (elementId.selector) {
+                        if (elementId === 'body') {
+                            elementId = 'body';
+                        } else if (elementId.selector) {
                             elementId = elementId.selector
                         } else {
                             elementId = elementId;

--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -22,7 +22,7 @@ const compareWithBaseline = require('../lib/compare-with-baseline')
  * @param {String} message Optional message for `nightwatch` to log upon completion
  */
 exports.assertion = function screenshotIdenticalToBaseline(
-    elementId = elementId || 'body',
+    elementId,
     fileName = elementId,
     settings,
     message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/nightwatch-vrt",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Nightwatch Visual Regression Testing tools",
     "license": "MIT",
     "homepage": "https://github.com/bbc/nightwatch-vrt",


### PR DESCRIPTION
## Problem
BBC Sport use this nightwatch package to do visual regression testing, but we do not currently use POM within our VRT suite. Instead we pass the selector directly as a string when using the assertion in `screenshotIdenticalToBaseline`. As a result, the feedback messages for us come back as `undefined` because `elementId.selector` does not exist as we're passing a string not an object.

## Proposed Solution
The fix is to check if the `elementId.selector` is true, then we set `elementId` to be the same as `elementId.selector` to ensure the feedback message is populated using the page object. If it doesnt exist, it falls back to using `elementId` itself.

## Testing
This appears to work as expected for BBC Sport's testing when run locally. It also appears to work for a simple POM based test I've put together, so I think it *should* continue to work as expected for anyone using this module and passing page-objects.