### PR TITLE
Handle edge case where rounding of diff to 2dp matches threshold

### DIFF
--- a/assertions/screenshotIdenticalToBaseline.js
+++ b/assertions/screenshotIdenticalToBaseline.js
@@ -58,15 +58,17 @@ exports.assertion = function screenshotIdenticalToBaseline(
             .perform((done) => {
                 compareWithBaseline(this.api, screenshot, fileName, settings).then((result) => {
                     comparisonResult = result ? result : result.value
+                    if (elementId === 'body') {
+                        elementId = 'body';
+                    } else if (elementId.selector) {
+                        elementId = elementId.selector
+                    } else {
+                        elementId = elementId;
+                    }
                     if(result.value === true && result.diff !== result.threshold) {
-                        if (elementId === 'body') {
-                            elementId = 'body';
-                        } else if (elementId.selector) {
-                            elementId = elementId.selector
-                        } else {
-                            elementId = elementId;
-                        }
                         this.message = `The difference between the screenshots for <${elementId}> was ${result.diff} when ${result.threshold} was expected`
+                    } else if(result.value === true && result.diff === result.threshold) {
+                        this.message = `The difference between the screenshot and baseline for <${elementId}> is less than 0.01. (Threshold: ${result.threshold} and Diff: ${result.fulldiff}) >`
                     }
                     done()
                 }, (reject) => {

--- a/lib/compare-with-baseline.js
+++ b/lib/compare-with-baseline.js
@@ -114,7 +114,7 @@ module.exports = function compareWithBaseline(
                         completeDiffPath
                     ), resolve)
                 .then(
-                    resolve({value:true, diff:diff.percent.toFixed(2), threshold:threshold.toFixed(2)})
+                    resolve({value:true, diff:diff.percent.toFixed(2), threshold:threshold.toFixed(2), fulldiff:diff.percent})
                 )
             } else if (identical) {
                 // Cleanup here in case user fixed bug and reran tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/nightwatch-vrt",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Nightwatch Visual Regression Testing tools",
     "license": "MIT",
     "homepage": "https://github.com/bbc/nightwatch-vrt",


### PR DESCRIPTION
## Description
When performing a comparison of the baseline and screenshot taken during execution, the `JIMP` library creates a diff value that runs to several decimal places. However, when the comparison function returns the result to the assertion, it rounds both the threshold value and the diff value to 2 decimal places.

As a result, in Sport we've seen some edge cases where a thin strip of pixels at the top of an image are enough to trigger a difference when doing the comparison, but we're not seeing the error message at line 69 of `assertions/screenshotIdenticalToBaseline.js` because the rounding of the diff.percent value means it is rounded to match the threshold. This has then caused a misunderstanding that the reported error (`expected "true" but got [object, object]`) was a _different_ failure than a simple comparison failure.

Solution:
Add an extra conditional to `assertions/screenshotIdenticalToBaseline.js` so that if the comparison fails but the diff and threshold are equal, throw a more useful error

## Ticket
[Comparison Rounding edge case](https://trello.com/c/OrBjuCl0/150-additional-error-handling-in-nightwatch-vrt-package)

## Checklist

### Module Admin
- [X] _**Required**_ Version bumped referencing [semver](https://semver.org/)

### Testing
- [X] _**Required**_ It works locally
- [X] Testing instructions added to ticket