### PR TITLE
Rewrite captureElementScreenshot to use new API function from Nightwatch v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ In order to use `nightwatch-vrt`, you only need to invoke the `screenshotIdentic
 
 ```JavaScript
 module.exports = {
-    'Test crunch.io main content is correct': (browser) => {
+    'Test Google UI loads correctly': (browser) => {
         browser
-            .url('https://crunch.io')
-            .assert.screenshotIdenticalToBaseline('.body.entry-content',  /* Optional */ 'custom-name', {threshold: 0.5}, 'VRT custom-name complete.')
+            .url('https://www.google.co.uk')
+            .assert.screenshotIdenticalToBaseline('body',  /* Optional */ 'custom-name', {threshold: 0.5}, 'VRT custom-name complete.')
             .end()
     }
 }

--- a/commands/captureElementScreenshot.js
+++ b/commands/captureElementScreenshot.js
@@ -28,7 +28,7 @@ CaptureElementScreenshot.prototype.command = function command(
     const api = this.client.api
 
     Promise.all([
-        promisifyCommand(api, 'getElementScreenshot', [selector])
+        promisifyCommand(api, 'takeElementScreenshot', [selector])
     ]).then(async ([screenshotEncoded]) => {
 
         Jimp.read(new Buffer(screenshotEncoded, 'base64')).then((screenshot) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bbc/nightwatch-vrt",
-    "version": "1.1.5",
+    "version": "2.0.0",
     "description": "Nightwatch Visual Regression Testing tools",
     "license": "MIT",
     "homepage": "https://github.com/bbc/nightwatch-vrt",


### PR DESCRIPTION
Nightwatch v2 upgrade has enabled us to rewrite the function that captured screenshots to use a function that screenshots the required element in a page, rather than taking the body and then attempting to crop the image.

It makes for a simpler file command *and* will hopefully help with some issues we were seeing in Sport when attempting to upgrade our test suite to NW v2

As the API command is introduced in NWv2, we're proposing a major version bump to allow any remaining teams to upgrade at their leisure